### PR TITLE
タイムスタンプの前後・メモリリークの修正

### DIFF
--- a/include/philosopher.h
+++ b/include/philosopher.h
@@ -42,6 +42,7 @@ typedef struct s_philo_inf
 	int				eat_num;
 	int				end_eat_flag;
 	int				end_eat_num_to_finish;
+	pthread_mutex_t	mut_action;
 }t_philo_inf;
 
 typedef struct s_philos
@@ -52,7 +53,6 @@ typedef struct s_philos
 	struct s_philos	*left;
 	struct s_philos	*right;
 	pthread_mutex_t	mut_fork;
-	pthread_mutex_t	mut_last_eat_time;
 }t_philos;
 
 /* main.c */

--- a/src/get_forks.c
+++ b/src/get_forks.c
@@ -6,7 +6,7 @@
 /*   By: yootaki <yootaki@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/11/07 22:36:46 by yootaki           #+#    #+#             */
-/*   Updated: 2021/11/21 20:33:38 by yootaki          ###   ########.fr       */
+/*   Updated: 2021/11/22 15:03:25 by yootaki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,12 +15,22 @@
 void	get_first_fork(t_philos *philo)
 {
 	pthread_mutex_lock(&philo->mut_fork);
+	if (philo->info->status == DIED)
+	{
+		pthread_mutex_unlock(&(philo->mut_fork));
+		return ;
+	}
 	print_philo_action(get_timestamp(), philo->id, GET_FORK);
 }
 
 void	get_second_fork(t_philos *philo)
 {
 	pthread_mutex_lock(&philo->left->mut_fork);
+	if (philo->info->status == DIED)
+	{
+		pthread_mutex_unlock(&(philo->left->mut_fork));
+		return ;
+	}
 	print_philo_action(get_timestamp(), philo->id, GET_FORK);
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -67,7 +67,7 @@ void	init_philos_struct(t_philos *philos, t_philo_inf *info)
 		philos->last_eat_time = (long *)malloc(sizeof(long));
 		*(philos->last_eat_time) = timestamp;
 		pthread_mutex_init(&philos->mut_fork, NULL);
-		pthread_mutex_init(&philos->mut_last_eat_time, NULL);
+		pthread_mutex_init(&philos->info->mut_action, NULL);
 		philos = philos->left;
 		i += 1;
 	}

--- a/src/philos_action.c
+++ b/src/philos_action.c
@@ -6,7 +6,7 @@
 /*   By: yootaki <yootaki@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/11/20 23:32:55 by yootaki           #+#    #+#             */
-/*   Updated: 2021/11/20 23:32:56 by yootaki          ###   ########.fr       */
+/*   Updated: 2021/11/22 15:04:51 by yootaki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,11 +36,16 @@ void	few_seconds_sleep(long after_time)
 /* Update the last time you ate and wait for an arbitrary number of seconds. */
 void	philo_eat(t_philos *philo)
 {
-	pthread_mutex_lock(&(philo->mut_last_eat_time));
+	pthread_mutex_lock(&(philo->info->mut_action));
+	if (philo->info->status == DIED)
+	{
+		pthread_mutex_unlock(&(philo->info->mut_action));
+		return ;
+	}
 	philo->info->eat_num += 1;
 	*(philo->last_eat_time) = get_timestamp();
-	pthread_mutex_unlock(&(philo->mut_last_eat_time));
 	print_philo_action(*(philo->last_eat_time), philo->id, EAT);
+	pthread_mutex_unlock(&(philo->info->mut_action));
 	few_seconds_sleep(*(philo->last_eat_time) + philo->info->time_to_eat);
 }
 
@@ -49,12 +54,26 @@ void	philo_sleep(t_philos *philo)
 {
 	long	time;
 
+	pthread_mutex_lock(&(philo->info->mut_action));
 	time = get_timestamp();
+	if (philo->info->status == DIED)
+	{
+		pthread_mutex_unlock(&(philo->info->mut_action));
+		return ;
+	}
 	print_philo_action(time, philo->id, SLEEP);
+	pthread_mutex_unlock(&(philo->info->mut_action));
 	few_seconds_sleep(time + philo->info->time_to_sleep);
 }
 
 void	philo_think(t_philos *philo)
 {
+	pthread_mutex_lock(&(philo->info->mut_action));
+	if (philo->info->status == DIED)
+	{
+		pthread_mutex_unlock(&(philo->info->mut_action));
+		return ;
+	}
 	print_philo_action(get_timestamp(), philo->id, THINK);
+	pthread_mutex_unlock(&(philo->info->mut_action));
 }


### PR DESCRIPTION
- 各アクションをプリントする前に哲学者が死亡していないか確認する条件文を追加。
- アクション実行時のmutexは全哲学者で共有するように変更し、タイムスタンプが前後するバグを修正。
- メモリリークしないようfreeする処理を追加。